### PR TITLE
Drain sink on stream destroy + destroy run-out test

### DIFF
--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -301,6 +301,12 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     s->flushed = 1;
   }
 
+  // A flush that errored after finalize_shards queued footer write_direct
+  // jobs returns before draining the sink. Drain unconditionally so no queued
+  // IO still references footer_buf_pool when shard_state_destroy frees it.
+  if (s->shard_sink)
+    shard_sink_drain(s->shard_sink);
+
   for (int lv = 0; lv < s->levels.nlod; ++lv) {
     shard_state_destroy(&s->shard[lv]);
     free(s->h_tail_bytes[lv]);

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -354,6 +354,13 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
+  // A flush that errored after finalize_shards queued footer write_direct
+  // jobs returns before draining the sink. Drain unconditionally so no queued
+  // IO still references footer_buf_pool when engine_array_state_destroy frees
+  // it below.
+  if (s->ctx.sink)
+    shard_sink_drain(s->ctx.sink);
+
   // s->ar owns the per-array allocations; the engine holds a bound copy of
   // the same pointers, so destroy strictly after engine teardown would
   // double-free — free once, here.

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -397,6 +397,13 @@ shard_pool_fs_inject_failing_truncate(struct shard_pool* self)
   return 0;
 }
 
+void
+shard_pool_fs_set_error(struct shard_pool* self)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  atomic_store(&p->io_error, 1);
+}
+
 struct gate_ctx
 {
   _Atomic int* gate;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -26,6 +26,9 @@ struct shard_pool_fs
   _Atomic uint64_t queued_bytes;
   _Atomic uint64_t retired_bytes;
   _Atomic int io_error;
+  // Test hook: one-shot. The next fs_slot_truncate fails before queueing its
+  // job, leaving any footer write_direct jobs from finalize_shards queued.
+  _Atomic int fail_next_truncate;
 };
 
 // --- Writer slot for a single shard file ---
@@ -39,6 +42,7 @@ struct fs_slot
   _Atomic uint64_t* retired_bytes; // points to shard_pool_fs.retired_bytes
   _Atomic uint64_t* queued_bytes;  // points to shard_pool_fs.queued_bytes
   _Atomic int* io_error;           // points to shard_pool_fs.io_error
+  _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
 };
 
 struct pwrite_job
@@ -206,6 +210,13 @@ fs_slot_truncate(struct shard_writer* self, uint64_t logical_size)
   struct fs_slot* w = (struct fs_slot*)self;
   if (w->fd == PLATFORM_FD_INVALID)
     return 0;
+
+  // A real truncate failure (truncate_fn) marks the pool errored; mirror that
+  // so a subsequent flush bails at its has_error gate before its own drain.
+  if (w->fail_next_truncate && atomic_exchange(w->fail_next_truncate, 0)) {
+    atomic_store(w->io_error, 1);
+    return 1;
+  }
 
   if (w->queue) {
     struct truncate_job* j =
@@ -378,6 +389,14 @@ shard_pool_fs_inject_failing_job(struct shard_pool* self)
   return io_queue_post(p->queue, fail_fn, (void*)&p->io_error, NULL);
 }
 
+int
+shard_pool_fs_inject_failing_truncate(struct shard_pool* self)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  atomic_store(&p->fail_next_truncate, 1);
+  return 0;
+}
+
 struct gate_ctx
 {
   _Atomic int* gate;
@@ -452,6 +471,7 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->retired_bytes = &p->retired_bytes;
     s->queued_bytes = &p->queued_bytes;
     s->io_error = &p->io_error;
+    s->fail_next_truncate = &p->fail_next_truncate;
   }
 
   return &p->base;

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -23,3 +23,10 @@ shard_pool_fs_inject_failing_job(struct shard_pool* pool);
 // Caller owns gate. Returns 0 on successful enqueue.
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
+
+// Test helper: one-shot. The next truncate fails before queueing its job,
+// so finalize_shards errors after it has already queued footer write_direct
+// jobs that reference footer_buf_pool. Exercises the destroy-time drain that
+// guards those buffers against a flush that bailed before its own drain.
+int
+shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -30,3 +30,9 @@ shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
 // guards those buffers against a flush that bailed before its own drain.
 int
 shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
+
+// Test helper: mark the pool errored immediately (synchronous, no queue).
+// Lets a test make every subsequent shard delivery short-circuit on
+// has_error so a kicked batch's delivery fails and stays queued at destroy.
+void
+shard_pool_fs_set_error(struct shard_pool* pool);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,7 @@ add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driv
 add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
+add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -142,6 +142,121 @@ Cleanup:
   return rc;
 }
 
+// Two pipelined batches kicked (both enqueued on the delivery worker), then
+// the sink is forced into an error state so each batch's delivery
+// short-circuits and fails. destroy's auto-flush aborts on the first failed
+// drain without joining the second batch's worker job, so a delivery job is
+// still queued when stop_join runs — the teardown run-out path. Asserts no
+// hang and (under ASAN) no use-after-free.
+static int
+test_destroy_runs_out_queued_delivery(const char* tmpdir)
+{
+  log_info("=== test_destroy_runs_out_queued_delivery ===");
+
+  struct dimension dims[3] = {
+    { .size = 12,
+      .chunk_size = 4,
+      .chunks_per_shard = 3,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 64,
+      .chunk_size = 16,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 64,
+      .chunk_size = 16,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 4 * 64 * 64;
+  const size_t append_elements = 4 * epoch_elements; // two full batches at K=2
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint16_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+
+  store = store_fs_create(tmpdir, 1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+    .epochs_per_batch = 2,
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)malloc(append_elements * sizeof(uint16_t));
+  CHECK(Cleanup, src);
+  for (size_t i = 0; i < append_elements; ++i)
+    src[i] = (uint16_t)(i * 31);
+
+  // Force the sink errored before the kicks so every delivery the worker
+  // attempts short-circuits on has_error and fails fast.
+  shard_pool_fs_set_error(pool);
+
+  {
+    struct slice input = { .beg = src, .end = src + append_elements };
+    // Append succeeds (the kick path does not check has_error); both batches
+    // are kicked and enqueued on the delivery worker, each failing on the
+    // sink error.
+    writer_append(tile_stream_gpu_writer(s), input);
+  }
+
+  // Destroy on another thread so a hung run-out shows up as a timeout rather
+  // than wedging the test.
+  struct destroy_args da = { .s = s };
+  atomic_store(&da.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
+  s = NULL;
+
+  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("destroy hung with a delivery job still queued");
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  // The sink is errored by construction; the point of the test is the clean
+  // teardown, which ASAN validates.
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_gpu_destroy(s);
+  test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
 // One full batch appended (slot kicked; its delivery ran on the worker and
 // queued sink IO), sink IO gated: destroy must block until the IO drains,
 // then finish clean.
@@ -281,6 +396,13 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/midstream_%d", tmpdir, rep);
     test_mkdir(sub);
     ecode |= test_destroy_with_delivery_in_flight(sub, rep);
+  }
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/runout", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_destroy_runs_out_queued_delivery(sub);
   }
 
   {

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,0 +1,146 @@
+// Regression test (#147): a writer_flush that errors after finalize_shards
+// has queued footer write_direct jobs returns before its own drain. Those
+// jobs reference stream-owned footer_buf_pool. tile_stream_cpu_destroy must
+// drain the sink unconditionally before shard_state_destroy frees that pool,
+// or the IO worker reads freed heap (use-after-free; ASAN catches it).
+
+#include "platform/platform.h"
+#include "store.h"
+#include "stream.cpu.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int
+test_destroy_drains_after_flush_error(const char* tmpdir)
+{
+  log_info("=== test_destroy_drains_after_flush_error (cpu) ===");
+
+  // Unbounded append dim with chunks_per_shard=2 and one appended epoch:
+  // the shard is partial at flush time, so finalize_shards queues a footer
+  // write_direct and then calls truncate, which the injected hook fails.
+  struct dimension dims[3] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 8 * 8;
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_cpu* s = NULL;
+  uint16_t* src = NULL;
+  int rc = 1;
+
+  store = store_fs_create(tmpdir, /*unbuffered=*/1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .epochs_per_batch = 1,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  s = tile_stream_cpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)calloc(epoch_elements, sizeof(uint16_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + epoch_elements };
+    struct writer_result r = writer_append(tile_stream_cpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // Make the next truncate fail. finalize_shards queues the footer
+  // write_direct first, then truncate fails, so the flush body returns error
+  // before reaching its own drain.
+  CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
+
+  {
+    struct writer_result r = writer_flush(tile_stream_cpu_writer(s));
+    if (!r.error) {
+      log_error("flush unexpectedly succeeded — fault hook not in effect");
+      goto Cleanup;
+    }
+  }
+
+  // Destroy with the footer jobs still queued and the pool errored. The
+  // unconditional drain must run them out before footer_buf_pool is freed.
+  tile_stream_cpu_destroy(s);
+  s = NULL;
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_cpu_destroy(s);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/flush_error_drain_cpu", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_destroy_drains_after_flush_error(sub);
+  }
+
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}


### PR DESCRIPTION
Closes #147.
Closes #152.

## #147 — flush error paths can free footer_buf with sink IO still pending (both backends)

`writer_flush` drains the sink IO queue only after `finalize_shards`. If the flush body errors between queueing a footer-referencing `write_direct` job and reaching the drain (e.g. a truncate/metadata-write failure after `finalize_shards` has queued footer jobs), it returns early without draining. Stream destroy then frees `footer_buf_pool` while the IO worker may still be parked before the write — the #145 use-after-free / on-disk-corruption class, behind an error precondition.

Fix: drain unconditionally on the destroy path of both backends, before the teardown that frees the footer pool — mirroring how #142 made gate release unconditional on destroy.
- GPU: `shard_sink_drain` in `tile_stream_gpu_destroy` before `engine_array_state_destroy`.
- CPU: `shard_sink_drain` in `tile_stream_cpu_destroy` before the `shard_state_destroy` loop.

New regression test `tests/test_flush_error_drain_cpu.c` (CPU-only): injects a one-shot failing truncate (new `shard_pool_fs_inject_failing_truncate` hook) so footer jobs stay queued when destroy runs; under ASAN, no use-after-free is the pass condition.

## #152 — test_destroy_midstream does not exercise the teardown run-out path

Both existing subtests auto-flush successfully before destroy, so the GPU worker queue is already empty when `gpu_delivery_stop_join` runs — the run-out line is verified by reasoning only.

New subtest forces a delivery to stay queued at destroy time by marking the pool errored up front (new synchronous `shard_pool_fs_set_error` hook), so every delivery short-circuits on `has_error`; then destroys from another thread and asserts no hang and no use-after-free under ASAN.

The two fault-injection helpers (`inject_failing_truncate`, one-shot/truncate-triggered; `set_error`, synchronous) are distinct and serve the two tests; both land here together.