### PR TITLE
bench: cycle distinct prefilled blocks to remove per-append fill

### DIFF
--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -506,10 +506,14 @@ run_bench(const struct bench_config* cfg)
 
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
+  double fill_s = 0.0;
   CHECK(Fail,
-        (cfg->prefill
-           ? pump_data_prefilled(bench_writer(&h), total_elements, fill)
-           : pump_data(bench_writer(&h), total_elements, fill)) == 0);
+        pump_data_modal(bench_writer(&h),
+                        total_elements,
+                        fill,
+                        dtype_bpe(dtype),
+                        cfg->pump_mode,
+                        &fill_s) == 0);
 
   size_t pending_bytes = bench_zarr_pending_bytes(&zarr);
 
@@ -552,6 +556,11 @@ run_bench(const struct bench_config* cfg)
                        init_s,
                        flush_s,
                        pending_bytes);
+
+    if (cfg->pump_mode != PUMP_CYCLE_BLOCKS || fill_s > 0)
+      print_report("  Data gen time: %.3f s (%.1f%% of wall)",
+                   fill_s,
+                   wall_s > 0 ? 100.0 * fill_s / wall_s : 0.0);
 
     if (cfg->json_output) {
       const struct stream_metric* sink_metric =
@@ -617,7 +626,7 @@ struct bench_cli_args
   uint64_t io_latency_us;
   size_t backpressure_bytes;
   int max_threads;
-  int prefill;
+  enum pump_mode pump_mode;
 };
 
 // Parse the shared bench CLI flags into out. Unknown options print a usage
@@ -651,7 +660,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
   out->io_latency_us = 0;
   out->backpressure_bytes = 0;
   out->max_threads = 0;
-  out->prefill = 0;
+  out->pump_mode = PUMP_CYCLE_BLOCKS;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -701,7 +710,9 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
     } else if (strcmp(av[i], "--max-threads") == 0 && i + 1 < ac) {
       out->max_threads = (int)strtol(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--prefill") == 0) {
-      out->prefill = 1;
+      out->pump_mode = PUMP_SINGLE_BLOCK;
+    } else if (strcmp(av[i], "--busy-producer") == 0) {
+      out->pump_mode = PUMP_BUSY_PRODUCER;
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -714,7 +725,9 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               "[--s3-throughput-gbps N]] "
               "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
               "[--backpressure N (bytes, e.g. 256M)] "
-              "[--max-threads N (0 = OpenMP default)] [--prefill]\n",
+              "[--max-threads N (0 = OpenMP default)] "
+              "[--busy-producer (regenerate input every append)] "
+              "[--prefill (one identical block, within-mode A/B only)]\n",
               av[0]);
       return 1;
     }
@@ -775,7 +788,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
-    .prefill = a.prefill,
+    .pump_mode = a.pump_mode,
   };
   ecode = run_bench(&cfg);
 
@@ -795,27 +808,74 @@ Fail:
 // ---------------------------------------------------------------------------
 
 // Interleaved pump: alternates writer_append between two writers in lockstep.
-// Each call pushes one chunk of data to each writer before advancing.
+// Each iteration pushes one chunk to each writer before advancing. The pump
+// mode (see test_data.h) decides how the chunk contents are produced; the
+// default cycles a handful of pre-generated distinct blocks with no in-loop
+// fill. Fill seconds are written to *out_fill_s when non-NULL.
 static int
 pump_data_interleaved(struct writer* w0,
                       struct writer* w1,
                       size_t total_elements,
                       fill_fn fill,
                       size_t bpe,
-                      int prefill)
+                      enum pump_mode mode,
+                      double* out_fill_s)
 {
   const size_t nelements = 32 * 1024 * 1024; // 32M elements per chunk
-  size_t alloc = nelements * (bpe > 2 ? bpe : 2);
-  uint16_t* data = (uint16_t*)malloc(alloc);
-  if (!data)
+  const size_t alloc = nelements * (bpe > 2 ? bpe : 2);
+
+  if (out_fill_s)
+    *out_fill_s = 0.0;
+
+  size_t nappends = total_elements / nelements;
+  if (total_elements % nelements)
+    nappends += 1;
+  if (nappends == 0)
+    nappends = 1;
+
+  size_t nblocks = 1;
+  if (mode == PUMP_CYCLE_BLOCKS) {
+    nblocks = PUMP_CYCLE_BLOCK_COUNT;
+    if (nblocks > nappends)
+      nblocks = nappends;
+  }
+
+  uint16_t** blocks = (uint16_t**)calloc(nblocks, sizeof(uint16_t*));
+  if (!blocks)
     return 1;
-  if (prefill)
-    fill(data,
+  for (size_t b = 0; b < nblocks; ++b) {
+    blocks[b] = (uint16_t*)malloc(alloc);
+    if (!blocks[b]) {
+      for (size_t j = 0; j < b; ++j)
+        free(blocks[j]);
+      free(blocks);
+      return 1;
+    }
+  }
+
+  struct platform_clock fill_clock = { 0 };
+  double fill_s = 0.0;
+  if (mode == PUMP_CYCLE_BLOCKS) {
+    if (out_fill_s)
+      platform_toc(&fill_clock);
+    for (size_t b = 0; b < nblocks; ++b)
+      fill(blocks[b], nelements, b * nelements, total_elements);
+    if (out_fill_s)
+      fill_s += (double)platform_toc(&fill_clock);
+  } else if (mode == PUMP_SINGLE_BLOCK) {
+    if (out_fill_s)
+      platform_toc(&fill_clock);
+    fill(blocks[0],
          nelements < total_elements ? nelements : total_elements,
          0,
          total_elements);
+    if (out_fill_s)
+      fill_s += (double)platform_toc(&fill_clock);
+  }
 
+  int err = 0;
   size_t off0 = 0, off1 = 0;
+  size_t b0 = 0, b1 = 0;
 
   while (off0 < total_elements || off1 < total_elements) {
     // --- stream 0 ---
@@ -823,14 +883,21 @@ pump_data_interleaved(struct writer* w0,
       size_t n = nelements;
       if (off0 + n > total_elements)
         n = total_elements - off0;
-      if (!prefill)
+      uint16_t* data = blocks[b0];
+      if (mode == PUMP_BUSY_PRODUCER) {
+        if (out_fill_s)
+          platform_toc(&fill_clock);
         fill(data, n, off0, total_elements);
+        if (out_fill_s)
+          fill_s += (double)platform_toc(&fill_clock);
+      }
+      b0 = (b0 + 1 == nblocks) ? 0 : b0 + 1;
       struct slice input = { .beg = data, .end = (char*)data + n * bpe };
       struct writer_result r = writer_append_wait(w0, input);
       if (r.error) {
         log_error("  stream-0 append failed at offset %zu", off0);
-        free(data);
-        return 1;
+        err = 1;
+        break;
       }
       off0 += n;
     }
@@ -840,24 +907,36 @@ pump_data_interleaved(struct writer* w0,
       size_t n = nelements;
       if (off1 + n > total_elements)
         n = total_elements - off1;
-      if (!prefill)
+      uint16_t* data = blocks[b1];
+      if (mode == PUMP_BUSY_PRODUCER) {
+        if (out_fill_s)
+          platform_toc(&fill_clock);
         fill(data, n, off1, total_elements);
+        if (out_fill_s)
+          fill_s += (double)platform_toc(&fill_clock);
+      }
+      b1 = (b1 + 1 == nblocks) ? 0 : b1 + 1;
       struct slice input = { .beg = data, .end = (char*)data + n * bpe };
       struct writer_result r = writer_append_wait(w1, input);
       if (r.error) {
         log_error("  stream-1 append failed at offset %zu", off1);
-        free(data);
-        return 1;
+        err = 1;
+        break;
       }
       off1 += n;
     }
   }
 
-  // flush both
   struct writer_result r0 = writer_flush(w0);
   struct writer_result r1 = writer_flush(w1);
-  free(data);
-  return r0.error || r1.error;
+  if (!err)
+    err = r0.error || r1.error;
+  for (size_t b = 0; b < nblocks; ++b)
+    free(blocks[b]);
+  free(blocks);
+  if (out_fill_s)
+    *out_fill_s = fill_s;
+  return err;
 }
 
 static int
@@ -983,9 +1062,10 @@ run_bench_two_streams(const struct bench_config* cfg)
   // Interleaved pump
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
+  double fill_s = 0.0;
   CHECK(Fail,
         pump_data_interleaved(
-          w0, w1, total_elements, fill, bpe, cfg->prefill) == 0);
+          w0, w1, total_elements, fill, bpe, cfg->pump_mode, &fill_s) == 0);
 
   // Flush zarr sinks before measuring wall time
   struct platform_clock flush_clock = { 0 };
@@ -1034,6 +1114,10 @@ run_bench_two_streams(const struct bench_config* cfg)
   if (flush_s > 0)
     print_report("  Flush time:    %.3f s", (double)flush_s);
   print_report("  Wall time:     %.3f s", (double)wall_s);
+  if (cfg->pump_mode != PUMP_CYCLE_BLOCKS || fill_s > 0)
+    print_report("  Data gen time: %.3f s (%.1f%% of wall)",
+                 fill_s,
+                 wall_s > 0 ? 100.0 * fill_s / wall_s : 0.0);
   print_report("  Throughput:    %.2f GiB/s (combined)",
                wall_s > 0 ? combined_gib / wall_s : 0.0);
 
@@ -1158,7 +1242,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
-    .prefill = a.prefill,
+    .pump_mode = a.pump_mode,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -54,7 +54,7 @@ struct bench_config
   uint64_t io_latency_us;     // 0 = no fixed per-job latency
   size_t backpressure_bytes;  // 0 = disabled; >0 = stall when pending > N
   int max_threads;            // 0 = OpenMP default (omp_get_max_threads)
-  int prefill;                // fill the pump buffer once, append repeatedly
+  enum pump_mode pump_mode;   // how the pump produces input (see test_data.h)
 };
 
 int

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,7 +150,7 @@ target_link_libraries(test_platform PUBLIC Threads::Threads)
 
 # Shared test data generation library
 add_test_lib(test_data test_data.c test_data.h)
-target_link_libraries(test_data PUBLIC stream_config writer chucky_log)
+target_link_libraries(test_data PUBLIC stream_config writer platform chucky_log)
 
 # Tests with zstd
 add_gpu_test_exe(test_stream          test_stream.c          LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd index_ops_util test_shard_sink test_gpu_helpers test_shard_verify test_voxel_encode)

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -1,5 +1,6 @@
 #include "test_data.h"
 #include "log/log.h"
+#include "platform/platform.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -136,30 +137,8 @@ dim_total_elements(const struct dimension* dims, uint8_t rank)
 int
 pump_data_bpe(struct writer* w, size_t total_elements, fill_fn fill, size_t bpe)
 {
-  const size_t nelements = 32 * 1024 * 1024; // 32M elements
-  // Allocate max(n*bpe, n*2) so fill (which writes uint16_t) always fits
-  size_t alloc = nelements * (bpe > 2 ? bpe : 2);
-  uint16_t* data = (uint16_t*)malloc(alloc);
-  if (!data)
-    return 1;
-
-  for (size_t offset = 0; offset < total_elements; offset += nelements) {
-    size_t n = nelements;
-    if (offset + n > total_elements)
-      n = total_elements - offset;
-    fill(data, n, offset, total_elements);
-    struct slice input = { .beg = data, .end = (char*)data + n * bpe };
-    struct writer_result r = writer_append_wait(w, input);
-    if (r.error) {
-      log_error("  append failed at offset %zu", offset);
-      free(data);
-      return 1;
-    }
-  }
-
-  struct writer_result r = writer_flush(w);
-  free(data);
-  return r.error;
+  return pump_data_modal(
+    w, total_elements, fill, bpe, PUMP_BUSY_PRODUCER, NULL);
 }
 
 int
@@ -168,21 +147,125 @@ pump_data(struct writer* w, size_t total_elements, fill_fn fill)
   return pump_data_bpe(w, total_elements, fill, sizeof(uint16_t));
 }
 
-int
-pump_data_prefilled(struct writer* w, size_t total_elements, fill_fn fill)
+static const size_t PUMP_BLOCK_ELEMENTS = 32 * 1024 * 1024; // 32M elements
+
+// Cycle through pre-generated distinct blocks (PUMP_CYCLE_BLOCKS). The blocks
+// are filled once with staggered offsets into the fill pattern, so contents
+// differ block-to-block while keeping the value distribution -- and thus the
+// compression ratio -- realistic. No fill runs inside the append loop.
+static int
+pump_cycle_blocks(struct writer* w,
+                  size_t total_elements,
+                  fill_fn fill,
+                  size_t bpe,
+                  double* out_fill_s)
 {
-  const size_t bpe = sizeof(uint16_t);
-  const size_t nelements = 32 * 1024 * 1024; // 32M elements
-  uint16_t* data = (uint16_t*)malloc(nelements * bpe);
+  const size_t nelements = PUMP_BLOCK_ELEMENTS;
+  const size_t block_alloc = nelements * (bpe > 2 ? bpe : 2);
+
+  size_t nappends = total_elements / nelements;
+  if (total_elements % nelements)
+    nappends += 1;
+  if (nappends == 0)
+    nappends = 1;
+
+  size_t nblocks = PUMP_CYCLE_BLOCK_COUNT;
+  if (nblocks > nappends)
+    nblocks = nappends;
+
+  uint16_t** blocks = (uint16_t**)calloc(nblocks, sizeof(uint16_t*));
+  if (!blocks)
+    return 1;
+  for (size_t b = 0; b < nblocks; ++b) {
+    blocks[b] = (uint16_t*)malloc(block_alloc);
+    if (!blocks[b]) {
+      for (size_t j = 0; j < b; ++j)
+        free(blocks[j]);
+      free(blocks);
+      return 1;
+    }
+  }
+
+  struct platform_clock fill_clock = { 0 };
+  if (out_fill_s)
+    platform_toc(&fill_clock);
+  for (size_t b = 0; b < nblocks; ++b)
+    fill(blocks[b], nelements, b * nelements, total_elements);
+  if (out_fill_s)
+    *out_fill_s = (double)platform_toc(&fill_clock);
+
+  int err = 0;
+  size_t b = 0;
+  for (size_t offset = 0; offset < total_elements; offset += nelements) {
+    size_t n = nelements;
+    if (offset + n > total_elements)
+      n = total_elements - offset;
+    uint16_t* data = blocks[b];
+    b = (b + 1 == nblocks) ? 0 : b + 1;
+    struct slice input = { .beg = data, .end = (char*)data + n * bpe };
+    struct writer_result r = writer_append_wait(w, input);
+    if (r.error) {
+      log_error("  append failed at offset %zu", offset);
+      err = 1;
+      break;
+    }
+  }
+
+  if (!err) {
+    struct writer_result r = writer_flush(w);
+    err = r.error;
+  }
+  for (size_t i = 0; i < nblocks; ++i)
+    free(blocks[i]);
+  free(blocks);
+  return err;
+}
+
+int
+pump_data_modal(struct writer* w,
+                size_t total_elements,
+                fill_fn fill,
+                size_t bpe,
+                enum pump_mode mode,
+                double* out_fill_s)
+{
+  if (out_fill_s)
+    *out_fill_s = 0.0;
+
+  if (mode == PUMP_CYCLE_BLOCKS)
+    return pump_cycle_blocks(w, total_elements, fill, bpe, out_fill_s);
+
+  const size_t nelements = PUMP_BLOCK_ELEMENTS;
+  // Allocate max(n*bpe, n*2) so fill (which writes uint16_t) always fits.
+  size_t alloc = nelements * (bpe > 2 ? bpe : 2);
+  uint16_t* data = (uint16_t*)malloc(alloc);
   if (!data)
     return 1;
-  fill(data, nelements < total_elements ? nelements : total_elements, 0,
-       total_elements);
+
+  struct platform_clock fill_clock = { 0 };
+  double fill_s = 0.0;
+  if (mode == PUMP_SINGLE_BLOCK) {
+    if (out_fill_s)
+      platform_toc(&fill_clock);
+    fill(data,
+         nelements < total_elements ? nelements : total_elements,
+         0,
+         total_elements);
+    if (out_fill_s)
+      fill_s += (double)platform_toc(&fill_clock);
+  }
 
   for (size_t offset = 0; offset < total_elements; offset += nelements) {
     size_t n = nelements;
     if (offset + n > total_elements)
       n = total_elements - offset;
+    if (mode == PUMP_BUSY_PRODUCER) {
+      if (out_fill_s)
+        platform_toc(&fill_clock);
+      fill(data, n, offset, total_elements);
+      if (out_fill_s)
+        fill_s += (double)platform_toc(&fill_clock);
+    }
     struct slice input = { .beg = data, .end = (char*)data + n * bpe };
     struct writer_result r = writer_append_wait(w, input);
     if (r.error) {
@@ -194,5 +277,7 @@ pump_data_prefilled(struct writer* w, size_t total_elements, fill_fn fill)
 
   struct writer_result r = writer_flush(w);
   free(data);
+  if (out_fill_s)
+    *out_fill_s = fill_s;
   return r.error;
 }

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -31,6 +31,28 @@ rand_pattern_free(void);
 size_t
 dim_total_elements(const struct dimension* dims, uint8_t rank);
 
+// How the pump produces the data it appends. The choice decides whether the
+// harness or the library dominates the measured wall time.
+enum pump_mode
+{
+  // Pre-generate a handful of distinct blocks once, then cycle through them
+  // one per append with no in-loop generation. Distinct contents keep
+  // compression ratios realistic; per-append cost is just the writer. Default.
+  PUMP_CYCLE_BLOCKS = 0,
+  // Regenerate the block on every append (the original behaviour). The fill
+  // thread competes with the library for host memory bandwidth -- use this to
+  // measure the library under a busy producer.
+  PUMP_BUSY_PRODUCER,
+  // Fill one block once and append it repeatedly. Cheapest, but every block has
+  // identical contents, so compressed-codec results are only comparable within
+  // this mode (within-mode A/B), not against the varied-data modes.
+  PUMP_SINGLE_BLOCK,
+};
+
+// Number of distinct blocks pre-generated and cycled by PUMP_CYCLE_BLOCKS.
+// Capped to the number of appends for small runs.
+#define PUMP_CYCLE_BLOCK_COUNT 8
+
 // Fill data, pump through writer, flush. Returns 0 on success.
 int
 pump_data(struct writer* w, size_t total_elements, fill_fn fill);
@@ -43,8 +65,14 @@ pump_data_bpe(struct writer* w,
               fill_fn fill,
               size_t bpe);
 
-// Fill the pump buffer once and append it repeatedly. Isolates the writer's
-// cost from the per-iteration fill (perf benches only — chunk contents
-// repeat with the buffer period).
+// Pump in the given mode. When out_fill_s is non-NULL, the seconds spent
+// generating data (block pre-generation for PUMP_CYCLE_BLOCKS, per-append fill
+// for PUMP_BUSY_PRODUCER) are written there so the report can attribute harness
+// time. Returns 0 on success.
 int
-pump_data_prefilled(struct writer* w, size_t total_elements, fill_fn fill);
+pump_data_modal(struct writer* w,
+                size_t total_elements,
+                fill_fn fill,
+                size_t bpe,
+                enum pump_mode mode,
+                double* out_fill_s);


### PR DESCRIPTION
Closes #150.

Streaming benches spent ~half their wall time generating their own input via the per-append `fill()` in `pump_data` / `pump_data_interleaved`, which understated library throughput ~2x and let the fill thread contend with the library for host memory bandwidth (medfmt/zstd regressed ~18% purely from contention).

Changes:
- New default pump mode cycles through up to 8 distinct pre-generated blocks (`PUMP_CYCLE_BLOCK_COUNT`), filled once with staggered offsets so contents differ block-to-block but keep the same value distribution — realistic compression ratios with zero per-append fill cost. Applied to both single-stream and the two-stream interleaved pump.
- `--busy-producer` keeps the original regenerate-every-append behavior as a host-bandwidth stress variant.
- `--prefill` (single identical block) retained for back-compat / writer-only ceiling.
- Both pumps now report `Data gen time` (seconds / % of wall) so harness cost is visible instead of folded into throughput.
- Incidental: the single-stream path previously ignored `--dtype` (always bpe=2); it now uses `dtype_bpe(dtype)`, matching the two-stream path.

A/B to validate: default vs `--busy-producer` throughput (expect ~2x gap; medfmt/zstd contention regression gone under default), and matching compressed bytes between default and busy modes (vs inflated ratio under `--prefill`).